### PR TITLE
feat: provide the parser as a nix package via the flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ dist
 *.o
 
 /examples/*/
+/result

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
     description = "Tree-sitter for the Astro SSG";
 
     inputs = {
-        flake-utils.url = github:numtide/flake-utils;
+        flake-utils.url = "github:numtide/flake-utils";
     };
 
     outputs = { self, nixpkgs, flake-utils }: flake-utils.lib.eachDefaultSystem (system: let
@@ -12,6 +12,11 @@
             buildInputs = with pkgs; [
                 tree-sitter
             ];
+        };
+        packages.default = pkgs.tree-sitter.buildGrammar {
+            language = "astro";
+            src = pkgs.lib.cleanSource ./.;
+            version = self.shortRev or "latest";
         };
     });
 }


### PR DESCRIPTION
This provides users of the parser on flake-based systems or projects a convenient way to install it.

It also opens up an ergonomic way to ensure the macos and linux CI on GHActions works the exact same way as locally