### PR TITLE
feat: provide nixpkgs overlay in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,18 +5,29 @@
         flake-utils.url = "github:numtide/flake-utils";
     };
 
-    outputs = { self, nixpkgs, flake-utils }: flake-utils.lib.eachDefaultSystem (system: let
+    outputs = { self, nixpkgs, flake-utils }: (flake-utils.lib.eachDefaultSystem (system: let
         pkgs = nixpkgs.legacyPackages.${system};
+
+        appliedOverlay = self.overlays.default pkgs pkgs;
     in {
         devShell = pkgs.mkShell {
             buildInputs = with pkgs; [
                 tree-sitter
             ];
         };
-        packages.default = pkgs.tree-sitter.buildGrammar {
-            language = "astro";
-            src = pkgs.lib.cleanSource ./.;
-            version = self.shortRev or "latest";
+
+        packages.default = appliedOverlay.tree-sitter.passthru.builtGrammars.tree-sitter-astro;
+    })) // {
+        overlays.default = final: prev: {
+            tree-sitter = prev.tree-sitter.override {
+                extraGrammars = {
+                    tree-sitter-astro = prev.tree-sitter.buildGrammar {
+                        language = "astro";
+                        src = prev.lib.cleanSource ./.;
+                        version = self.shortRev or "latest";
+                    };
+                };
+            };
         };
-    });
+    };
 }


### PR DESCRIPTION
This PR adds on to the work in #32, providing an overlay that can be added to a nixpkgs set. Passing a grammar into `tree-sitter`'s `extraGrammars` argument is typically what most NixOS users would want to do, so that editors like Emacs can use those grammars. This makes consuming the repo in a flake-based NixOS config very easy, by simply including `inputs.astro-tree-sitter.overlays.default` in the nixpkgs set's overlays.