### PR TITLE
bindings(rust): Add queries to rust binding

### DIFF
--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -35,8 +35,8 @@ pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
 // Uncomment these to include any queries that this grammar contains
 
-// pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
-// pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
+pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
+pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
 // pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
 // pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
 

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,7 @@
         devShell = pkgs.mkShell {
             buildInputs = with pkgs; [
                 tree-sitter
+                cargo
             ];
         };
 


### PR DESCRIPTION
The Rust bindings were missing the imports for the queries.
This PR adds them

Also adds cargo to the devShell